### PR TITLE
Add entry of unit testing.

### DIFF
--- a/quic_transport/BUILD.gn
+++ b/quic_transport/BUILD.gn
@@ -94,11 +94,11 @@ shared_library("owt_quic_transport") {
 test("owt_quic_transport_tests") {
   testonly = true
   sources = [
-    "//net/test/run_all_unittests.cc",
+    "impl/proof_source_owt_unittest.cc",
     "impl/quic_transport_factory_impl_unittest.cc",
     "impl/tests/quic_transport_owt_end_to_end_test.cc",
+    "impl/tests/run_all_unittests.cc",
     "impl/version_unittest.cc",
-    "impl/proof_source_owt_unittest.cc",
   ]
   configs += [
     "//build/config:precompiled_headers",

--- a/quic_transport/impl/tests/run_all_unittests.cc
+++ b/quic_transport/impl/tests/run_all_unittests.cc
@@ -1,0 +1,23 @@
+/*
+ * Copyright (C) 2020 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// Copyright (c) 2012 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "base/bind.h"
+#include "base/test/launcher/unit_test_launcher.h"
+#include "net/socket/transport_client_socket_pool.h"
+#include "net/test/net_test_suite.h"
+
+int main(int argc, char** argv) {
+  NetTestSuite test_suite(argc, argv);
+  net::TransportClientSocketPool::set_connect_backup_jobs_enabled(false);
+
+  return base::LaunchUnitTests(
+      argc, argv,
+      base::BindOnce(&NetTestSuite::Run, base::Unretained(&test_suite)));
+}


### PR DESCRIPTION
Entry of unit testing for net checks build is timely. We don't need it at this time.