### PR TITLE
Call thread unsafe methods from the same thread.

### DIFF
--- a/quic_transport/impl/quic_transport_owt_server_dispatcher.cc
+++ b/quic_transport/impl/quic_transport_owt_server_dispatcher.cc
@@ -38,8 +38,8 @@ QuicTransportOwtServerDispatcher::QuicTransportOwtServerDispatcher(
     std::unique_ptr<QuicAlarmFactory> alarm_factory,
     uint8_t expected_server_connection_id_length,
     std::vector<url::Origin> accepted_origins,
-    base::TaskRunner* task_runner,
-    base::TaskRunner* event_runner)
+    base::SingleThreadTaskRunner* task_runner,
+    base::SingleThreadTaskRunner* event_runner)
     : QuicDispatcher(config,
                      crypto_config,
                      version_manager,

--- a/quic_transport/impl/quic_transport_owt_server_dispatcher.h
+++ b/quic_transport/impl/quic_transport_owt_server_dispatcher.h
@@ -15,7 +15,7 @@
 #ifndef OWT_QUIC_QUIC_TRANSPORT_QUIC_TRANSPORT_OWT_SERVER_DISPATCHER_H_
 #define OWT_QUIC_QUIC_TRANSPORT_QUIC_TRANSPORT_OWT_SERVER_DISPATCHER_H_
 
-#include "base/task_runner.h"
+#include "base/single_thread_task_runner.h"
 #include "net/third_party/quiche/src/quic/core/quic_dispatcher.h"
 #include "url/origin.h"
 
@@ -39,8 +39,8 @@ class QuicTransportOwtServerDispatcher : public ::quic::QuicDispatcher {
       std::unique_ptr<::quic::QuicAlarmFactory> alarm_factory,
       uint8_t expected_server_connection_id_length,
       std::vector<url::Origin> accepted_origins,
-      base::TaskRunner* task_runner,
-      base::TaskRunner* event_runner);
+      base::SingleThreadTaskRunner* task_runner,
+      base::SingleThreadTaskRunner* event_runner);
   void SetVisitor(Visitor* visitor);
 
   ~QuicTransportOwtServerDispatcher() override;
@@ -55,8 +55,8 @@ class QuicTransportOwtServerDispatcher : public ::quic::QuicDispatcher {
 
   std::vector<url::Origin> accepted_origins_;
   Visitor* visitor_;
-  base::TaskRunner* runner_;
-  base::TaskRunner* event_runner_;
+  base::SingleThreadTaskRunner* runner_;
+  base::SingleThreadTaskRunner* event_runner_;
 };
 }  // namespace quic
 }  // namespace owt

--- a/quic_transport/impl/quic_transport_owt_server_session.cc
+++ b/quic_transport/impl/quic_transport_owt_server_session.cc
@@ -36,8 +36,8 @@ QuicTransportOwtServerSession::QuicTransportOwtServerSession(
     const ::quic::QuicCryptoServerConfig* crypto_config,
     ::quic::QuicCompressedCertsCache* compressed_certs_cache,
     std::vector<url::Origin> accepted_origins,
-    base::TaskRunner* runner,
-    base::TaskRunner* event_runner)
+    base::SingleThreadTaskRunner* runner,
+    base::SingleThreadTaskRunner* event_runner)
     : QuicTransportServerSession(connection,
                                  owner,
                                  config,
@@ -69,7 +69,7 @@ const char* QuicTransportOwtServerSession::ConnectionId() {
 
 QuicTransportStreamInterface*
 QuicTransportOwtServerSession::CreateBidirectionalStream() {
-  if (thread_checker_.CalledOnValidThread()) {
+  if (runner_->BelongsToCurrentThread()) {
     return CreateBidirectionalStreamOnCurrentThread();
   }
   QuicTransportStreamInterface* result(nullptr);

--- a/quic_transport/impl/quic_transport_owt_server_session.h
+++ b/quic_transport/impl/quic_transport_owt_server_session.h
@@ -45,8 +45,8 @@ class QuicTransportOwtServerSession
       const ::quic::QuicCryptoServerConfig* crypto_config,
       ::quic::QuicCompressedCertsCache* compressed_certs_cache,
       std::vector<url::Origin> accepted_origins,
-      base::TaskRunner* runner,
-      base::TaskRunner* event_runner);
+      base::SingleThreadTaskRunner* runner,
+      base::SingleThreadTaskRunner* event_runner);
   ~QuicTransportOwtServerSession() override;
 
   // Override QuicTransportSessionInterface.
@@ -71,10 +71,9 @@ class QuicTransportOwtServerSession
   std::vector<url::Origin> accepted_origins_;
   owt::quic::QuicTransportSessionInterface::Visitor* visitor_;
   std::vector<std::unique_ptr<QuicTransportStreamImpl>> streams_;
-  base::TaskRunner* runner_;
-  base::TaskRunner* event_runner_;
+  base::SingleThreadTaskRunner* runner_;
+  base::SingleThreadTaskRunner* event_runner_;
   ConnectionStats stats_;
-  base::ThreadChecker thread_checker_;
   base::WeakPtrFactory<QuicTransportOwtServerSession> weak_factory_{this};
 };
 

--- a/quic_transport/impl/quic_transport_stream_impl.h
+++ b/quic_transport/impl/quic_transport_stream_impl.h
@@ -16,7 +16,7 @@
 #define OWT_QUIC_QUIC_TRANSPORT_QUIC_TRANSPORT_STREAM_IMPL_H_
 
 #include "base/memory/weak_ptr.h"
-#include "base/task_runner.h"
+#include "base/single_thread_task_runner.h"
 #include "base/threading/thread_checker.h"
 #include "net/third_party/quiche/src/quic/quic_transport/quic_transport_stream.h"
 #include "owt/quic/quic_transport_stream_interface.h"
@@ -30,8 +30,8 @@ class QuicTransportStreamImpl : public QuicTransportStreamInterface,
                                 public ::quic::QuicTransportStream::Visitor {
  public:
   explicit QuicTransportStreamImpl(::quic::QuicTransportStream* stream,
-                                   base::TaskRunner* runner,
-                                   base::TaskRunner* event_runner);
+                                   base::SingleThreadTaskRunner* runner,
+                                   base::SingleThreadTaskRunner* event_runner);
   ~QuicTransportStreamImpl() override;
 
   // Overrides QuicTransportStreamInterface.
@@ -51,10 +51,9 @@ class QuicTransportStreamImpl : public QuicTransportStreamInterface,
 
  protected:
   ::quic::QuicTransportStream* stream_;
-  base::TaskRunner* runner_;
-  base::TaskRunner* event_runner_;
+  base::SingleThreadTaskRunner* io_runner_;
+  base::SingleThreadTaskRunner* event_runner_;
   owt::quic::QuicTransportStreamInterface::Visitor* visitor_;
-  base::ThreadChecker thread_checker_;
 
  private:
   void WriteOnCurrentThread(std::vector<uint8_t> data);


### PR DESCRIPTION
ThreadChecker always returns true for CalledOnValidThread in release build. Update the implementation of stream to use another way to check thread.