### PR TITLE
Signal before return.

### DIFF
--- a/quic_transport/impl/quic_transport_owt_client_impl.cc
+++ b/quic_transport/impl/quic_transport_owt_client_impl.cc
@@ -129,12 +129,15 @@ void QuicTransportOwtClientImpl::ConnectOnCurrentThread(
 void QuicTransportOwtClientImpl::CloseOnCurrentThread(
     base::WaitableEvent* event) {
   if (client_ == nullptr) {
+    event->Signal();
     return;
   }
   if (client_->session() == nullptr) {
+    event->Signal();
     return;
   }
   if (client_->session()->connection() == nullptr) {
+    event->Signal();
     return;
   }
   CHECK(client_);


### PR DESCRIPTION
Caller keeps waiting if event is not signaled.